### PR TITLE
build: update javadoc links & enable JDK 23 builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,6 +30,9 @@ jobs:
           - jdk: '21'
             distribution: zulu
             experimental: false
+          - jdk: '23'
+            distribution: zulu
+            experimental: false
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -456,8 +456,8 @@
             <!--            <doclint>none</doclint>-->
             <doclint>all,-accessibility,-html,-missing</doclint>
             <links>
-              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
-              <link>https://docs.oracle.com/javaee/7/api/</link>
+              <link>https://docs.oracle.com/en/java/javase/17/docs/api/</link>
+              <link>https://jakarta.ee/specifications/platform/9/apidocs/</link>
               <link>https://jena.apache.org/documentation/javadoc/jena/</link>
               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
               <link>https://guava.dev/releases/${v.guava}/api/docs/</link>


### PR DESCRIPTION
## Description

_What does this PR do..._

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
