### PR TITLE
refactor: get rid of Guava

### DIFF
--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/OslcOAuthClient.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/OslcOAuthClient.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
+import org.eclipse.lyo.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +58,7 @@ public class OslcOAuthClient implements IOslcClient {
 
         oauthRealmName = "Jazz";
         // Change if a different name was detected
-        if (!StringUtils.isEmpty(realm)) {
+        if (!StringUtils.isNullOrEmpty(realm)) {
             oauthRealmName = realm;
         }
 

--- a/core/lyo-core-settings/pom.xml
+++ b/core/lyo-core-settings/pom.xml
@@ -82,10 +82,6 @@
       <artifactId>jersey-common</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/core/util/StringUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/core/util/StringUtils.java
@@ -1,8 +1,27 @@
-package org.eclipse.lyo.oslc4j.core;
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License 1.0
+ * which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lyo.core.util;
 
 import java.util.regex.Pattern;
 
+/**
+ * @since 7.0.0
+ */
 public class StringUtils {
+    /**
+     * Pattern to match control characters in the Unicode Cc category that are not CR, LF, or TAB
+     */
     private static final Pattern CONTROL_CHAR_PATTERN = Pattern.compile("^\\p{Cc}&&[^\\r\\n\\t]+$");
 
     /**
@@ -26,7 +45,6 @@ public class StringUtils {
     public static boolean isNullOrWhitespace(String str) {
         return str == null || str.isBlank();
     }
-
 
     public static boolean isNullOrEmpty(String str) {
         return str == null || str.isEmpty();

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/core/util/StringUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/core/util/StringUtils.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.lyo.core.util;
 
+import java.text.Normalizer;
 import java.util.regex.Pattern;
 
 /**
@@ -25,21 +26,45 @@ public class StringUtils {
     private static final Pattern CONTROL_CHAR_PATTERN = Pattern.compile("^\\p{Cc}&&[^\\r\\n\\t]+$");
 
     /**
-     * Trim and strip control chars
+     * Trim and strip control chars (in the Unicode Cc category that are not CR, LF, or TAB)
      */
-    public static String clean(String str) {
+    public static String cleanWithoutNormalization(String str) {
         if (str == null) return null;
 
         return CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim();
     }
 
     /**
-     * Trim and strip control chars; return an empty string if a null is encountered
+     * Trim and strip control chars (in the Unicode Cc category that are not CR, LF, or TAB);
+     * returns an empty string if a null is encountered
+     */
+    public static String cleanWithoutNormalizationNonNull(String str) {
+        if (str == null) return "";
+
+        return CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim();
+    }
+
+    /**
+     * Trim, strip control chars (in the Unicode Cc category that are not CR, LF, or TAB), and
+     * normalize the string to NFC as per W3C recommendations
+     */
+    public static String clean(String str) {
+        if (str == null) return null;
+
+        return Normalizer.normalize(CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim(),
+            Normalizer.Form.NFC);
+    }
+
+    /**
+     * Trim, strip control chars (in the Unicode Cc category that are not CR, LF, or TAB), and
+     * normalize the string to NFC as per W3C recommendations;
+     * returns an empty string if a null is encountered
      */
     public static String cleanNonNull(String str) {
         if (str == null) return "";
 
-        return CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim();
+        return Normalizer.normalize(CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim(),
+            Normalizer.Form.NFC);
     }
 
     public static boolean isNullOrWhitespace(String str) {

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -36,7 +36,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import com.google.common.base.Strings;
 import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
@@ -550,7 +549,7 @@ public class OSLC4JUtils {
 			final boolean defaultValue) {
 		Boolean value;
 		final String property = System.getProperty(key);
-		if (Strings.isNullOrEmpty(property)) {
+		if (StringUtils.isNullOrEmpty(property)) {
 			value = defaultValue;
 		} else {
 			try {

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -43,6 +43,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.datatypes.xsd.impl.XMLLiteralType;
 import org.apache.jena.rdf.model.Property;
+import org.eclipse.lyo.core.util.StringUtils;
 import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
 import org.eclipse.lyo.oslc4j.core.model.XMLLiteral;
 import org.slf4j.Logger;

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/StringUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/StringUtils.java
@@ -1,0 +1,34 @@
+package org.eclipse.lyo.oslc4j.core;
+
+import java.util.regex.Pattern;
+
+public class StringUtils {
+    private static final Pattern CONTROL_CHAR_PATTERN = Pattern.compile("^\\p{Cc}&&[^\\r\\n\\t]+$");
+
+    /**
+     * Trim and strip control chars
+     */
+    public static String clean(String str) {
+        if (str == null) return null;
+
+        return CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim();
+    }
+
+    /**
+     * Trim and strip control chars; return an empty string if a null is encountered
+     */
+    public static String cleanNonNull(String str) {
+        if (str == null) return "";
+
+        return CONTROL_CHAR_PATTERN.matcher(str).replaceAll("").trim();
+    }
+
+    public static boolean isNullOrWhitespace(String str) {
+        return str == null || str.isBlank();
+    }
+
+
+    public static boolean isNullOrEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
+}

--- a/core/oslc4j-jena-provider/pom.xml
+++ b/core/oslc4j-jena-provider/pom.xml
@@ -131,11 +131,6 @@
       <version>${v.jersey}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelperTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelperTest.java
@@ -17,9 +17,9 @@ package org.eclipse.lyo.oslc4j.provider.jena;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.util.List;
 import javax.xml.datatype.DatatypeConfigurationException;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.rdf.model.Model;
 import org.eclipse.lyo.oslc4j.core.exception.LyoModelException;
@@ -53,7 +53,7 @@ public class JenaModelHelperTest {
         final Model expectedModel = RDFHelper.loadResourceModel("container-element.ttl");
         final Container container = new Container();
         container.setAbout(URI.create("urn:containerA"));
-        final ImmutableList<Element> children = ImmutableList.of(element("A"), element("B"));
+        final List<Element> children = List.of(element("A"), element("B"));
         container.setChildrenL(children);
         container.setChildrenB(children);
 

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
@@ -18,10 +18,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
-import com.google.common.collect.ImmutableList;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 import org.eclipse.lyo.oslc4j.provider.jena.OslcJsonLdArrayProvider;
@@ -72,7 +73,7 @@ public class JsonLdTest {
                 .getAnnotations(), OslcMediaType.APPLICATION_JSON_LD_TYPE, new
                 MultivaluedHashMap<>(), outputStream);
 
-        final String jsonLD = outputStream.toString("UTF-8");
+        final String jsonLD = outputStream.toString(StandardCharsets.UTF_8);
 
         assertTrue("Provider was not read", jsonLD.contains("Hello world"));
 
@@ -94,7 +95,7 @@ public class JsonLdTest {
                          new MultivaluedHashMap<>(),
                          outputStream);
 
-        final String jsonLD = outputStream.toString("UTF-8");
+        final String jsonLD = outputStream.toString(StandardCharsets.UTF_8);
 
         assertTrue("Provider was not read", jsonLD.contains("Hello world"));
     }
@@ -107,7 +108,7 @@ public class JsonLdTest {
 
         ServiceProvider sp = new ServiceProvider();
         sp.setDescription("Hello world");
-        final Collection<ServiceProvider> objects = ImmutableList.of(sp);
+        final Collection<ServiceProvider> objects = List.of(sp);
         provider.writeTo(
             new ArrayList<>(objects),
                 objects.getClass(),
@@ -117,7 +118,7 @@ public class JsonLdTest {
                 new MultivaluedHashMap<>(),
                 outputStream);
 
-        final String jsonLD = outputStream.toString("UTF-8");
+        final String jsonLD = outputStream.toString(StandardCharsets.UTF_8);
 
         assertTrue("Provider was not read", jsonLD.contains("Hello world"));
     }

--- a/core/shacl/pom.xml
+++ b/core/shacl/pom.xml
@@ -27,10 +27,6 @@
       <artifactId>oslc4j-jena-provider</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/Shape.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/Shape.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.lyo.shacl;
 
-import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +25,6 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 /**
  * @author Yash Khatri
- * @version $version-stub$
  * @since 2.3.0
  */
 @OslcNamespace(ShaclConstants.SHACL_CORE_NAMESPACE)
@@ -133,8 +131,7 @@ public final class Shape extends AbstractResource {
     @OslcTitle("Properties")
     @OslcValueType(ValueType.LocalResource)
     public List<Property> getShaclProperties() {
-        return ImmutableList.copyOf(
-                properties.values().toArray(new Property[properties.size()]));
+        return List.of(properties.values().toArray(new Property[0]));
     }
 
     public void setShaclProperties(final List<Property> properties) {

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,6 @@
     <v.jackson>2.18.2</v.jackson>
     <v.httpclient>4.5.14</v.httpclient>
     <v.slf4j>2.0.16</v.slf4j>
-
-    <v.guava>33.3.1-jre</v.guava>
   </properties>
 
 
@@ -394,11 +392,6 @@
         <version>1.17.1</version>
       </dependency>
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${v.guava}</version>
-      </dependency>
-      <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
         <version>2.1.3</version>
@@ -476,7 +469,6 @@
               <link>https://jakarta.ee/specifications/platform/9/apidocs/</link>
               <link>https://jena.apache.org/documentation/javadoc/jena/</link>
               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
-              <link>https://guava.dev/releases/${v.guava}/api/docs/</link>
             </links>
           </configuration>
           <executions>

--- a/server/oslc-ui-model/pom.xml
+++ b/server/oslc-ui-model/pom.xml
@@ -25,10 +25,6 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
         </dependency>
-        <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </dependency>
     </dependencies>
     <build>
       <plugins>

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
@@ -15,7 +15,7 @@ package org.eclipse.lyo.server.ui.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
+import org.eclipse.lyo.core.util.StringUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
@@ -143,7 +143,7 @@ public class PreviewFactory {
         if (null == link) {
             return null;
         }
-        if (StringUtils.isBlank(link.getLabel())) {
+        if (StringUtils.isNullOrWhitespace(link.getLabel())) {
             return constructLink(link.getValue().toString(), link.getValue().toString());
         } else {
             return constructLink(link.getValue().toString(), link.getLabel());

--- a/store/store-core/pom.xml
+++ b/store/store-core/pom.xml
@@ -101,10 +101,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -33,7 +33,6 @@ import javax.xml.datatype.DatatypeConfigurationException;
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.arq.querybuilder.DescribeBuilder;
 import org.apache.jena.arq.querybuilder.ExprFactory;
 import org.apache.jena.arq.querybuilder.Order;
@@ -67,6 +66,7 @@ import org.eclipse.lyo.core.query.StringValue;
 import org.eclipse.lyo.core.query.UriRefValue;
 import org.eclipse.lyo.core.query.Value;
 import org.eclipse.lyo.core.query.WhereClause;
+import org.eclipse.lyo.core.util.StringUtils;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
@@ -295,8 +295,8 @@ public class SparqlStoreImpl implements Store {
         String _prefixes = prefixes;
         String _where = where;
 
-        _prefixes = (StringUtils.isEmpty(_prefixes) ? "" : _prefixes + ",") + oslcQueryPrefixes(clazz);
-        _where = (StringUtils.isEmpty(_where) ? "" : _where + " and ") + oslcQueryWhere(clazz);
+        _prefixes = (StringUtils.isNullOrEmpty(_prefixes) ? "" : _prefixes + ",") + oslcQueryPrefixes(clazz);
+        _where = (StringUtils.isNullOrEmpty(_where) ? "" : _where + " and ") + oslcQueryWhere(clazz);
         Model model = getResources(namedGraph, _prefixes, _where, searchTerms, limit, offset, additionalDistinctVars,
             additionalQueryFilter);
         return getResourcesFromModel(model, clazz);
@@ -595,7 +595,7 @@ public class SparqlStoreImpl implements Store {
         //Setup prefixes
         Map<String, String> prefixesMap = new HashMap<>();
         try {
-            if (!StringUtils.isEmpty(prefixes)) {
+            if (!StringUtils.isNullOrEmpty(prefixes)) {
                 prefixesMap = QueryUtils.parsePrefixes(prefixes);
                 for (Entry<String, String> prefix : prefixesMap.entrySet()) {
                     distinctResourcesQuery.addPrefix(prefix.getKey(), prefix.getValue());
@@ -622,7 +622,7 @@ public class SparqlStoreImpl implements Store {
         //Setup where
         WhereClause whereClause = null;
         try {
-            if (!StringUtils.isEmpty(where)) {
+            if (!StringUtils.isNullOrEmpty(where)) {
                 whereClause = QueryUtils.parseWhere(where, prefixesMap);
                 List<SimpleTerm> parseChildren = whereClause.children();
                 for (SimpleTerm simpleTerm : parseChildren) {
@@ -672,7 +672,7 @@ public class SparqlStoreImpl implements Store {
 
         //Setup searchTerms
         //Add a sparql filter "FILTER regex(?o, "<searchTerms>", "i")" to the distinctResourcesQuery
-        if (!StringUtils.isEmpty(searchTerms)) {
+        if (!StringUtils.isNullOrEmpty(searchTerms)) {
             ExprFactory factory = new ExprFactory();
             E_Regex regex = factory.regex(factory.str("?o"), searchTerms, "i");
             distinctResourcesQuery.addFilter(regex);

--- a/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
+++ b/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -33,8 +35,6 @@ import org.junit.jupiter.api.Test;
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-
-import com.google.common.base.Stopwatch;
 
 public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
 
@@ -68,7 +68,7 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
     @Test
     public void testInsertionPerf() {
         final List<ServiceProvider> providers = genProviders();
-        final Stopwatch stopwatch = Stopwatch.createStarted();
+        var start = Instant.now();
         for (int i = 0; i < 10; i++) {
             final URI testNg = URI.create("urn:test:" + i);
             try {
@@ -77,7 +77,7 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
                 fail("Store failed", e);
             }
         }
-        System.out.printf("10 named graphs persisted (resources) in %s ms", stopwatch.stop().elapsed().toMillis());
+        System.out.printf("10 named graphs persisted (resources) in %s ms", Duration.between(start, Instant.now()).toMillis());
     }
 
     @Test
@@ -85,12 +85,12 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
             OslcCoreApplicationException, IllegalAccessException {
         final List<ServiceProvider> providers = genProviders();
         final Model jenaModel = JenaModelHelper.createJenaModel(providers.toArray());
-        final Stopwatch stopwatch = Stopwatch.createStarted();
+        var start = Instant.now();
         for (int i = 0; i < 10; i++) {
             final URI testNg = URI.create("urn:test:" + i);
             manager.insertJenaModel(testNg, jenaModel);
         }
-        System.out.printf("10 named graphs persisted (raw Model) in %s ms", stopwatch.stop().elapsed().toMillis());
+        System.out.printf("10 named graphs persisted (raw Model) in %s ms", Duration.between(start, Instant.now()).toMillis());
     }
 
     private List<ServiceProvider> genProviders() {

--- a/store/store-core/src/test/java/org/eclipse/lyo/store/StoreTestBase.java
+++ b/store/store-core/src/test/java/org/eclipse/lyo/store/StoreTestBase.java
@@ -38,9 +38,6 @@ import org.junit.jupiter.api.Test;
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 
 /**
  * StoreTestBase allows same tests to be run on differently set up triplestores
@@ -143,7 +140,7 @@ public abstract class StoreTestBase<T extends Store> {
                 ServiceProviderCatalog.class);
 
         Assertions.assertThat(catalogs).hasSize(2);
-        Assertions.assertThat(Lists.newArrayList(catalogs)
+        Assertions.assertThat(catalogs
                 .stream()
                 .map((serviceProviderCatalog) -> serviceProviderCatalog.getAbout().toASCIIString()))
                 .contains(resource.getAbout().toASCIIString(),
@@ -190,7 +187,7 @@ public abstract class StoreTestBase<T extends Store> {
                 resource2.getAbout(), ServiceProviderCatalog.class);
 
         Assertions.assertThat(resourceUnderKey).isNotNull();
-        Assertions.assertThat(resourceUnderKey.getAbout().equals(resource2.getAbout()));
+        Assertions.assertThat(resourceUnderKey.getAbout()).isEqualTo(resource2.getAbout());
     }
 
     @Test
@@ -228,7 +225,7 @@ public abstract class StoreTestBase<T extends Store> {
         final Store manager = buildStore();
 
         final URI namedGraphUri = new URI("urn:test");
-        manager.putResources(namedGraphUri, ImmutableList.of(r1WithBlankResource));
+        manager.putResources(namedGraphUri, List.of(r1WithBlankResource));
 
         final WithBlankResource resource = manager.getResource(
                 namedGraphUri,
@@ -259,7 +256,7 @@ public abstract class StoreTestBase<T extends Store> {
         final Store manager = buildStore();
 
         final URI namedGraphUri = new URI("urn:test");
-        manager.putResources(namedGraphUri, ImmutableList.of(aWithTwoDepthBlankResource));
+        manager.putResources(namedGraphUri, List.of(aWithTwoDepthBlankResource));
 
         final WithTwoDepthBlankResource resource = manager.getResource(namedGraphUri,
                                                                        blankResourceURI,

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -115,10 +115,6 @@
       <version>${v.lyo}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-repository-sparql</artifactId>
     </dependency>

--- a/trs/server/pom.xml
+++ b/trs/server/pom.xml
@@ -186,9 +186,5 @@
       <version>${v.slf4j}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/service/TrackedResourceSetService.java
+++ b/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/service/TrackedResourceSetService.java
@@ -25,7 +25,7 @@ import org.eclipse.lyo.core.trs.Page;
 import org.eclipse.lyo.core.trs.TRSConstants;
 import org.eclipse.lyo.core.trs.TrackedResourceSet;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
-import org.eclipse.lyo.oslc4j.core.StringUtils;
+import org.eclipse.lyo.core.util.StringUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcService;
 import org.eclipse.lyo.oslc4j.core.model.Error;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;

--- a/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/service/TrackedResourceSetService.java
+++ b/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/service/TrackedResourceSetService.java
@@ -19,13 +19,13 @@ import java.net.URISyntaxException;
 
 import jakarta.inject.Inject;
 
-import com.google.common.base.Strings;
 import org.eclipse.lyo.core.trs.Base;
 import org.eclipse.lyo.core.trs.ChangeLog;
 import org.eclipse.lyo.core.trs.Page;
 import org.eclipse.lyo.core.trs.TRSConstants;
 import org.eclipse.lyo.core.trs.TrackedResourceSet;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
+import org.eclipse.lyo.oslc4j.core.StringUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcService;
 import org.eclipse.lyo.oslc4j.core.model.Error;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
@@ -197,7 +197,7 @@ public class TrackedResourceSetService {
     }
 
     private UriBuilder uriBuilder() {
-        if(Strings.isNullOrEmpty(base)) {
+        if(StringUtils.isNullOrEmpty(base)) {
             return UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(RESOURCE_PATH);
         } else {
             return UriBuilder.fromUri(base);

--- a/trs/server/src/test/java/org/eclipse/lyo/oslc4j/trs/server/InmemPagedTrsTest.java
+++ b/trs/server/src/test/java/org/eclipse/lyo/oslc4j/trs/server/InmemPagedTrsTest.java
@@ -1,12 +1,12 @@
 package org.eclipse.lyo.oslc4j.trs.server;
 
-import com.google.common.collect.ImmutableSet;
 
 import java.math.BigInteger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.lyo.core.trs.Base;
 import org.eclipse.lyo.core.trs.ChangeEvent;
@@ -30,7 +30,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testEmptyLogWithBase() {
-        final InmemPagedTrs inmemPagedTrs = buildPagedTrs(ImmutableSet.of(TRSTestUtil.dummyUri(), TRSTestUtil
+        final InmemPagedTrs inmemPagedTrs = buildPagedTrs(Set.of(TRSTestUtil.dummyUri(), TRSTestUtil
                 .dummyUri()));
 
         final Base base = inmemPagedTrs.getBaseResource(1);
@@ -40,7 +40,7 @@ public class InmemPagedTrsTest {
     @Test
     public void testEmptyLogWithPagedBase() {
         final InmemPagedTrs inmemPagedTrs = buildPagedTrs(
-                ImmutableSet.of(TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(), TRSTestUtil
+                Set.of(TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(), TRSTestUtil
                                 .dummyUri(), TRSTestUtil.dummyUri(),
                         TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri()));
 
@@ -55,7 +55,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testLogWithEmptyBase() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
@@ -68,7 +68,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testPagedLogWithEmptyBase() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
@@ -87,7 +87,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testLogOrderUnique() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
@@ -112,7 +112,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testLogOrderMonotonic() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
@@ -137,7 +137,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testLogPagesLinked() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
@@ -153,7 +153,7 @@ public class InmemPagedTrsTest {
 
     @Test
     public void testLogPagesLinkedFirstNil() {
-        final InmemPagedTrs pagedTrs = buildPagedTrs(ImmutableSet.of());
+        final InmemPagedTrs pagedTrs = buildPagedTrs(Set.of());
 
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());
         pagedTrs.onHistoryData(TRSTestUtil.createHistory());

--- a/trs/server/src/test/java/org/eclipse/lyo/oslc4j/trs/server/service/TRSServiceResource.java
+++ b/trs/server/src/test/java/org/eclipse/lyo/oslc4j/trs/server/service/TRSServiceResource.java
@@ -1,5 +1,7 @@
 package org.eclipse.lyo.oslc4j.trs.server.service;
 
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.UriBuilder;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.trs.server.InmemPagedTrs;
 import org.eclipse.lyo.oslc4j.trs.server.PagedTrs;
@@ -7,10 +9,7 @@ import org.eclipse.lyo.oslc4j.trs.server.TRSTestUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.UriBuilder;
+import java.util.List;
 
 @Path("/trs")
 public class TRSServiceResource extends TrackedResourceSetService {
@@ -24,8 +23,9 @@ public class TRSServiceResource extends TrackedResourceSetService {
     protected PagedTrs getPagedTrs() {
         log.trace("Change History objects requested");
         final InmemPagedTrs inmemPagedTrs = new InmemPagedTrs(5, 5,
-                UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("trs").build(), ImmutableList.of(TRSTestUtil.dummyUri(),TRSTestUtil.dummyUri(),TRSTestUtil.dummyUri(),TRSTestUtil.dummyUri(),TRSTestUtil.dummyUri()));
-//        inmemPagedTrs.onHistoryData(TRSTestUtil.createHistory());
+            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("trs").build(),
+            List.of(TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri(),
+                TRSTestUtil.dummyUri(), TRSTestUtil.dummyUri()));
         return inmemPagedTrs;
     }
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -50,11 +50,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
     <!-- OSLC Core Libraries -->
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>


### PR DESCRIPTION
## Description

Gets rid of the Google Guava dependency. Rationale: reduce dependency list both to reduce maintenance burden for us and pass on size reduction for the users.

We only used string blankness checks as well as some immutable collection and stopwatch functionality. All has been replaced by JDK11/17+ code and a small `StringUtil` class.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #650

_(use exactly this syntax to link to issues, one issue per statement only!)_
