### PR TITLE
fix: avoid duplicating scanned classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This release does not introduce deprecations.
 ### Fixed
 
 - Client now picks the correct ResponseInfo object when an OSLC Query response contains multiple ResponseInfo objects.
+- Lyo object-graph mapping (OGM) framework no longer registers duplicate classes when doing recursive scans. 
 
 ## [6.0.0]
 

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
@@ -49,7 +49,7 @@ public class ResourcePackages {
     /**
      * The RDFs-Classes types mapping.
      */
-    static final Map<String, List<Class<?>>> TYPES_MAPPINGS = new HashMap<>();
+    static final Map<String, Set<Class<?>>> TYPES_MAPPINGS = new HashMap<>();
 
     private ResourcePackages() {}
 
@@ -78,7 +78,7 @@ public class ResourcePackages {
                             Class<?> rdfClass = Class.forName(classInfo.getName(), true,
                                 Thread.currentThread().getContextClassLoader());
                             String rdfType = TypeFactory.getQualifiedName(rdfClass);
-                            List<Class<?>> types = TYPES_MAPPINGS.computeIfAbsent(rdfType, k -> new ArrayList<>());
+                            var types = TYPES_MAPPINGS.computeIfAbsent(rdfType, k -> new HashSet<>());
                             types.add(rdfClass);
                             counter ++;
                             LOGGER.trace("[+] {} -> {}", rdfType, rdfClass);
@@ -157,12 +157,13 @@ public class ResourcePackages {
             while(rdfTypes.hasNext()) {
                 Statement statement = rdfTypes.nextStatement();
                 String typeURI = statement.getObject().asResource().getURI();
-                List<Class<?>> rdfClasses = TYPES_MAPPINGS.get(typeURI);
+                var rdfClasses = TYPES_MAPPINGS.get(typeURI);
                 if (rdfClasses == null) {
                     LOGGER.trace("[-] Unmapped class(es) for RDF:type {}", typeURI);
                 } else if (rdfClasses.size() == 1) {
-                    candidates.add(rdfClasses.get(0));
-                    LOGGER.trace("[+] Candidate class {} found for RDF:type {}", rdfClasses.get(0).getName(), typeURI);
+                    var candidate = rdfClasses.stream().findFirst().get();
+                    candidates.add(candidate);
+                    LOGGER.trace("[+] Candidate class {} found for RDF:type {}", candidate.getName(), typeURI);
                 } else if (preferredTypes.length == 0) {
                     StringBuilder sb = new StringBuilder();
                     sb.append("'preferredTypes' argument is required when more than one class (");

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
@@ -1,15 +1,16 @@
 package org.eclipse.lyo.oslc4j.provider.jena.ordfm;
 
 import java.util.Optional;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Cat;
-import org.eclipse.lyo.oslc4j.provider.jena.resources.Dog;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Pet;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.WildDog;
+import org.eclipse.lyo.oslc4j.provider.jena.resources.child.ChildAnimal;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,19 +47,25 @@ public class ResourcePackagesTests {
         }
 
         Assert.assertEquals(1, ResourcePackages.SCANNED_PACKAGES.size());
-        Assert.assertEquals(7, ResourcePackages.TYPES_MAPPINGS.keySet().size());
+        Assert.assertEquals(8, ResourcePackages.TYPES_MAPPINGS.keySet().size());
     }
 
     @Test
     public void testMapPackageTwice() {
+        ResourcePackages.mapPackage(ChildAnimal.class.getPackage());
         ResourcePackages.mapPackage(Pet.class.getPackage());
-        ResourcePackages.mapPackage(Dog.class.getPackage());
+        // parent package
         for (String aPackage : ResourcePackages.SCANNED_PACKAGES) {
             log.info("Scanned package: {}", aPackage);
         }
 
-        Assert.assertEquals(1, ResourcePackages.SCANNED_PACKAGES.size());
-        Assert.assertEquals(7, ResourcePackages.TYPES_MAPPINGS.keySet().size());
+        Assert.assertEquals(2, ResourcePackages.SCANNED_PACKAGES.size());
+        Assert.assertEquals(8, ResourcePackages.TYPES_MAPPINGS.keySet().size());
+        // ensure the ChildAnimal class is mapped once
+        Assert.assertEquals(1, ResourcePackages.TYPES_MAPPINGS.entrySet().stream()
+            .flatMap(it1 -> it1.getValue().stream())
+            .filter(it -> it.getCanonicalName().equals(ChildAnimal.class.getCanonicalName()))
+            .count());
     }
 
     @Test

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
@@ -7,6 +7,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Cat;
+import org.eclipse.lyo.oslc4j.provider.jena.resources.Dog;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Pet;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.WildDog;
 import org.junit.After;
@@ -40,6 +41,18 @@ public class ResourcePackagesTests {
     @Test
     public void testMapPackage() {
         ResourcePackages.mapPackage(Pet.class.getPackage());
+        for (String aPackage : ResourcePackages.SCANNED_PACKAGES) {
+            log.info("Scanned package: {}", aPackage);
+        }
+
+        Assert.assertEquals(1, ResourcePackages.SCANNED_PACKAGES.size());
+        Assert.assertEquals(7, ResourcePackages.TYPES_MAPPINGS.keySet().size());
+    }
+
+    @Test
+    public void testMapPackageTwice() {
+        ResourcePackages.mapPackage(Pet.class.getPackage());
+        ResourcePackages.mapPackage(Dog.class.getPackage());
         for (String aPackage : ResourcePackages.SCANNED_PACKAGES) {
             log.info("Scanned package: {}", aPackage);
         }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
@@ -54,7 +54,6 @@ public class ResourcePackagesTests {
     public void testMapPackageTwice() {
         ResourcePackages.mapPackage(ChildAnimal.class.getPackage());
         ResourcePackages.mapPackage(Pet.class.getPackage());
-        // parent package
         for (String aPackage : ResourcePackages.SCANNED_PACKAGES) {
             log.info("Scanned package: {}", aPackage);
         }
@@ -63,7 +62,7 @@ public class ResourcePackagesTests {
         Assert.assertEquals(8, ResourcePackages.TYPES_MAPPINGS.keySet().size());
         // ensure the ChildAnimal class is mapped once
         Assert.assertEquals(1, ResourcePackages.TYPES_MAPPINGS.entrySet().stream()
-            .flatMap(it1 -> it1.getValue().stream())
+            .flatMap(it -> it.getValue().stream())
             .filter(it -> it.getCanonicalName().equals(ChildAnimal.class.getCanonicalName()))
             .count());
     }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/resources/child/ChildAnimal.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/resources/child/ChildAnimal.java
@@ -1,0 +1,36 @@
+package org.eclipse.lyo.oslc4j.provider.jena.resources.child;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.provider.jena.resources.Pet;
+
+/**
+ * A concrete base class for Pet implementations.
+ * @author rherrera
+ */
+@OslcNamespace("http://locahost:7001/vocabulary/")
+@OslcResourceShape(title = "AbstractTypesTest2")
+public class ChildAnimal extends AbstractResource implements Pet {
+
+    private String name;
+
+    @Override
+    @OslcPropertyDefinition("http://locahost:7001/vocabulary/name")
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void eat() {
+        System.out.println("Eating like an animal");
+    }
+
+
+}


### PR DESCRIPTION
## Description

Switch to Set instead of List for keeping a map of all RDF type URI to POJOs to avoid dupe POJO entries in the map.

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #673