### PR TITLE
Update OSLC domains  LyoDesigner model to use 7.0.0-SNAPSHOT

### DIFF
--- a/domains/org.eclipse.lyo.tools.domainmodels/oslcDomainSpecifications.xml
+++ b/domains/org.eclipse.lyo.tools.domainmodels/oslcDomainSpecifications.xml
@@ -538,6 +538,6 @@
   <domainPrefixes name="oslc_promcode"/>
   <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
     <generalConfiguration filesBasePath="." javaBasePackageName="org.eclipse.lyo.oslc.domains"/>
-    <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" lyoVersion="6.0.0-SNAPSHOT" groupId="org.eclipse.lyo" artifactId="oslc-domains" version="6.0.0-SNAPSHOT"/>
+    <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" lyoVersion="7.0.0-SNAPSHOT" groupId="org.eclipse.lyo" artifactId="oslc-domains" version="7.0.0-SNAPSHOT"/>
   </configuration>
 </oslc4j_ai:Specification>

--- a/domains/oslc-domains/pom.xml
+++ b/domains/oslc-domains/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <!-- Start of user code header
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <!-- Start of user code header
     -->
   <!-- TODO: Add additional header properties here to avoid them be overrriden
   upon future re-generation -->
@@ -15,54 +15,46 @@
   </parent>
   <!-- End of user code
     -->
-  <groupId>org.eclipse.lyo</groupId>
-  <artifactId>oslc-domains</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
-  <name>Lyo :: Domains</name>
-  <properties>
-    <!-- Start of user code properties
+    <groupId>org.eclipse.lyo</groupId>
+    <artifactId>oslc-domains</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Lyo :: Domains</name>
+    <properties>
+        <!-- Start of user code properties
             -->
     <!-- TODO: Add additional properties here to avoid them be overrriden upon
     future re-generation -->
     <!-- End of user code
         -->
-  </properties>
-  <!-- Start of user code pre_dependencies
+    </properties>
+    <!-- Start of user code pre_dependencies
     -->
   <!-- End of user code
     -->
-  <dependencies>
-    <!-- Specific dependencies -->
-    <!-- Start of user code dependencies
+    <dependencies>
+        <!-- Specific dependencies -->
+        <!-- Start of user code dependencies
                 -->
     <!-- TODO: Add additional dependencies here to avoid them be overrriden upon
     future re-generation -->
     <!-- End of user code
         -->
-    <!-- General dependencies -->
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.servlet.jsp.jstl</groupId>
-      <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-    </dependency>
-
-    <!-- Lyo dependencies -->
-    <dependency>
-      <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-      <artifactId>oslc4j-core</artifactId>
-    </dependency>
-    <!-- Start of user code dependencies_final
+        <!-- General dependencies -->
+        <!-- Lyo dependencies -->
+        <dependency>
+            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+            <artifactId>oslc4j-core</artifactId>
+        </dependency>
+        
+        <!-- Start of user code dependencies_final
         -->
     <!-- TODO: Add additional dependencies here to avoid them be overridden upon
     future re-generation -->
     <!-- End of user code
         -->
-  </dependencies>
-  <!-- Start of user code post_dependencies
+    </dependencies>
+    <!-- Start of user code post_dependencies
     -->
   <build>
     <plugins>


### PR DESCRIPTION
## Description

Update OSLC domains  LyoDesigner model to use 7.0.0-SNAPSHOT

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [X] This PR does NOT break the API

