### PR TITLE
Release 7.0.0.Alpha3

### DIFF
--- a/client/oslc-client-base/pom.xml
+++ b/client/oslc-client-base/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
   </parent>
 
   <artifactId>oslc-client-base</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <name>Lyo :: Client :: Base</name>
 
   <properties>

--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>oslc-client</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <name>Lyo :: Client :: OSLC JAX-RS 2.0 (new)</name>
   <description>Eclipse Lyo OSLC Java client based on OSLC4J and JAX-RS 2.0</description>
 

--- a/client/oslc-java-client-resources/pom.xml
+++ b/client/oslc-java-client-resources/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
   </parent>
 
   <artifactId>oslc-java-client-resources</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <name>Lyo :: Client :: Resources (legacy)</name>
 
   <properties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,13 +6,13 @@
 
   <groupId>org.eclipse.lyo.clients</groupId>
   <artifactId>clients-parent</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <packaging>pom</packaging>
   <name>Lyo :: Client :: _Parent</name>
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/lyo-core-model/pom.xml
+++ b/core/lyo-core-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <name>Lyo :: Core :: OSLC Core model</name>

--- a/core/lyo-core-settings/pom.xml
+++ b/core/lyo-core-settings/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>oslc4j-core-build</artifactId>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/oslc-query/pom.xml
+++ b/core/oslc-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/core/oslc-trs/pom.xml
+++ b/core/oslc-trs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/core/oslc4j-core-build/pom.xml
+++ b/core/oslc4j-core-build/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/oslc4j-core-wink/pom.xml
+++ b/core/oslc4j-core-wink/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <artifactId>oslc4j-core-wink</artifactId>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <artifactId>oslc4j-core</artifactId>

--- a/core/oslc4j-jena-provider/pom.xml
+++ b/core/oslc4j-jena-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <artifactId>oslc4j-jena-provider</artifactId>

--- a/core/oslc4j-json4j-provider/pom.xml
+++ b/core/oslc4j-json4j-provider/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <artifactId>oslc4j-json4j-provider</artifactId>

--- a/core/oslc4j-utils/pom.xml
+++ b/core/oslc4j-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../oslc4j-core-build/pom.xml</relativePath>
     </parent>
     <name>Lyo :: Core :: Utilities</name>

--- a/core/shacl/pom.xml
+++ b/core/shacl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/domains/oslc-domains/pom.xml
+++ b/domains/oslc-domains/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <!-- End of user code
     -->
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>oslc-domains</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <packaging>jar</packaging>
     <name>Lyo :: Domains</name>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo</groupId>
   <artifactId>lyo-parent</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <packaging>pom</packaging>
   <name>Lyo :: _Parent</name>
 

--- a/server/net.oauth.core-oauth-consumer-jakarta/pom.xml
+++ b/server/net.oauth.core-oauth-consumer-jakarta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <groupId>org.eclipse.lyo.server</groupId>

--- a/server/net.oauth.core-oauth-httpclient4-jakarta/pom.xml
+++ b/server/net.oauth.core-oauth-httpclient4-jakarta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <groupId>org.eclipse.lyo.server</groupId>

--- a/server/net.oauth.core-oauth-jakarta/pom.xml
+++ b/server/net.oauth.core-oauth-jakarta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <groupId>org.eclipse.lyo.server</groupId>

--- a/server/net.oauth.core-oauth-provider-jakarta/pom.xml
+++ b/server/net.oauth.core-oauth-provider-jakarta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oauth-consumer-store/pom.xml
+++ b/server/oauth-consumer-store/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oauth-core/pom.xml
+++ b/server/oauth-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oauth-webapp/pom.xml
+++ b/server/oauth-webapp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oslc-ui-model/pom.xml
+++ b/server/oslc-ui-model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>7.0.0.Alpha3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -6,14 +6,14 @@
 
   <groupId>org.eclipse.lyo.store</groupId>
   <artifactId>store-parent</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <packaging>pom</packaging>
   <name>Lyo :: Store :: _Parent</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
   </parent>
 
   <properties>

--- a/store/store-core/pom.xml
+++ b/store/store-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.lyo.store</groupId>
     <artifactId>store-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/trs/client/client-source-mqtt/pom.xml
+++ b/trs/client/client-source-mqtt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
     <artifactId>trs-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/trs/client/pom.xml
+++ b/trs/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
     <artifactId>trs-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/trs/server/pom.xml
+++ b/trs/server/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo.trs</groupId>
   <artifactId>trs-server</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <name>Lyo :: TRS :: Server</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <!--	<groupId>org.eclipse.lyo</groupId>-->
   <artifactId>lyo-validation</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.0.Alpha3</version>
   <name>Lyo :: Validation</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.0.Alpha3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

Release 7.0.0.Alpha3. Changes:

- Lyo object-graph mapping (OGM) framework no longer registers duplicate classes when doing recursive scans. 
- Got rid of a direct dependency on Google Guava

Partly using this as an opportunity to check that Eclipse CI infra has fully recovered indeed.

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
